### PR TITLE
Update of Polish translation

### DIFF
--- a/src/main/resources/assets/horsestatsmod/lang/pl_pl.json
+++ b/src/main/resources/assets/horsestatsmod/lang/pl_pl.json
@@ -11,5 +11,5 @@
   "horsestatsmod.sprint": "sprint",
   "horsestatsmod.min": "min.",
   "horsestatsmod.max": "max.",
-  "horsestatsmod.loading": "Załadunek..."
+  "horsestatsmod.loading": "Ładowanie..."
 }


### PR DESCRIPTION
In this pull request I corrected the new incorrectly translated line.

For more context, "załadunek" is used when loading a cargo onto a truck, for example, which is clearly not what you would expect from this mod. Have you used a translation software to translate the new text string? They are still not good enough ;)