### PR TITLE
Update HorseStatsMod.java

### DIFF
--- a/src/main/java/dev/gallon/horsestatsmod/HorseStatsMod.java
+++ b/src/main/java/dev/gallon/horsestatsmod/HorseStatsMod.java
@@ -251,7 +251,7 @@ public class HorseStatsMod
                         3.689713992 * Math.pow(jumpHeight, 2) +
                         2.128599134 * jumpHeight - 0.343930367
         ); // convert to blocks
-        speed = speed * 43; // convert to m/s
+        speed = speed * 42.16; // convert to m/s
     }
 
     private void displayStatsInHoveringText(HorseInventoryScreen guiContainer, int mouseX, int mouseY) {


### PR DESCRIPTION
The conversion factor between internal units and blocks/sec is roughly 43.17. However, horses instead travel at just shy of 42.16 blocks/sec times their internal attribute

https://minecraft.wiki/w/Horse#:~:text=The%20conversion%20factor%20between%20internal%20units%20and%20blocks/sec%20is%20roughly%2043.17.%20However%2C%20horses%20instead%20travel%20at%20just%20shy%20of%2042.16%20blocks/sec%20times%20their%20internal%20attribute%2C%20putting%20the%20best%20horse%27s%20maximum%20speed%20at%2014.23%20blocks/second%2C%20and%20the%20average%20horse%27s%20speed%20at%20about%209.49%20blocks/sec.