### PR TITLE
Polish translation update

### DIFF
--- a/common/src/main/resources/assets/horsestatsmod/lang/pl_pl.json
+++ b/common/src/main/resources/assets/horsestatsmod/lang/pl_pl.json
@@ -8,9 +8,15 @@
   "horsestatsmod.meters_per_seconds": "m/s",
   "horsestatsmod.player": "Gracz",
   "horsestatsmod.walk": "chód",
-  "horsestatsmod.sprint": "sprint",
+  "horsestatsmod.sprint": "bieg",
   "horsestatsmod.min": "min.",
   "horsestatsmod.max": "max.",
   "horsestatsmod.loading": "Ładowanie...",
-  "horsestatsmod.owner": "Właściciel"
+  "horsestatsmod.owner": "Właściciel",
+  "horsestatsmod.configuration.HorseStatsMod": "Konfiguracja moda HorseStatsMod",
+  "text.autoconfig.horsestatsmod.title": "Konfiguracja moda HorseStatsMod",
+  "text.autoconfig.horsestatsmod.option.modConfig": "Konfiguracja moda HorseStatsMod",
+  "text.autoconfig.horsestatsmod.option.modConfig.displayStats": "Wyświetlanie statystyk w końskim ekwipunku",
+  "text.autoconfig.horsestatsmod.option.modConfig.coloredStats": "Wyświetlanie statystyk z użyciem kolorów",
+  "text.autoconfig.horsestatsmod.option.modConfig.displayMinMax": "Wyświetlanie statystyk z wartościami min. i max."
 }


### PR DESCRIPTION
In this pull request, I updated the Polish translation to include all the new text strings from commits b9bdfe76277c986e221853bc8feb8c805eae5fa2, cae35794b518a03e796ae3d529a35eebc8178d35, and 206a991e732b79c4029ecfae9e195a1adaf6f5ed. I also took the opportunity to improve one of the existing text strings.

However, I would also like to point out that a significant portion of the config is untranslatable, particularly the detailed in-game option descriptions in tooltips (see the attached screenshot below).

It would be much better if the translation was 100% complete instead of being a mix of two languages like it is now. Especially since, in the eyes of Polish users, it may seem that I cut corners. Which, obviously, is not true, but they won't know that :/

The NeoForged Team recommends the following to mod developers:
> (...) be sure to add translations for your configs! If you visit all your config screen pages and then back out to the mod list, all untranslated config entries encountered will be printed to the console to make it easier to know what to translate and what the translation keys are.

Source: https://neoforged.net/news/21.0release/#config-gui-returns-added-in-neoforge-210110-beta

Could you please look into this? This pull request can wait if necessary.

![Untranslatable-option-descriptions](https://github.com/user-attachments/assets/c6a7088c-1561-48d9-8ec0-57012e8d06fb)